### PR TITLE
set up login page; added homepage.css for future styling

### DIFF
--- a/src/scripts/Nutshell.js
+++ b/src/scripts/Nutshell.js
@@ -1,3 +1,5 @@
 export const Nutshell = () => {
     // Render all your UI components here
+    console.log("Nutshell has been rendered!")
+    console.log("Session storage user id: ", sessionStorage.getItem("activeUser") )
 }

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -2,6 +2,7 @@ import { LoginForm } from "./auth/LoginForm.js"
 import { RegisterForm } from "./auth/RegisterForm.js"
 import { Nutshell } from "./Nutshell.js"
 
+const eventHub = document.querySelector(".container")
 
 /*
     1. Check if the user is authenticated by looking in session storage for `activeUser`
@@ -10,3 +11,20 @@ import { Nutshell } from "./Nutshell.js"
     4. Also, if the user authenticates, and the login form is initially shown
         ensure that the Nutshell component gets rendered
 */
+
+// Check sessionStorage for a value for activeUser using .getItem(<key>)
+// Call login and register if .getItem returns null
+// Add event listener to trigger nutshell when sessionStorage changes
+
+if (sessionStorage.getItem("activeUser") === null) {
+    RegisterForm()
+    LoginForm()
+
+    // LoginForm() dispatches the "userAuthenticated" custom event when
+    // sessionStorage is set. 
+    eventHub.addEventListener("userAuthenticated", (CustomEvent) => {
+        Nutshell()
+    })
+} else { // If "activeUser" exists, go straight to Nutshell UI
+    Nutshell()
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,0 +1,1 @@
+@import "homepage.css";


### PR DESCRIPTION
# Description
Added code to main.js that checks for an "activeUser" key in session storage. If no key exists, register and login forms are loaded to the DOM. If an activeUser key does exist, either at page load or as a result of a user logging in, the Nutshell components are then loaded to the DOM.

Fixes # 15
## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)
# Testing Instructions
1. Serve the src folder and the api (port 8088)
2. Ensure that there is a "users" table in the JSON database
3. Load webpage; initial load should show a login form that accepts a username, and a register form that accepts a username and password
4. Fill out the register form and click the Register button. You should immediately be logged in using these credentials, and the two forms should disappear
5. Check the console for logs confirming that Nutshell was loaded and that the "activeUser" key in sessionStorage has a value
6. Close the browser window, then open up a new window and run localHost again to reset session storage
7. Attempt to log in using a preexisting username. Take note of the console logs.
# Checklist:
- [✅ ] My code follows the style guidelines of this project
- [✅] I have performed a self-review of my own code
- [✅] I have commented my code, particularly in hard-to-understand areas
- [✅] My changes generate no new warnings or errors
- [✅] I have added test instructions that prove my fix is effective or that my feature works
