### PR TITLE
Gt friends

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -17,7 +17,6 @@
         </article>
         <article class="dashboard">
             <!-- All your Nutshell are belong here -->
-            <section class="friend__container"></section>
             <section class="events">
                 <section class="dashboard__events"></section>
                 <div class="dashboard__events--button"></div>  
@@ -29,7 +28,7 @@
                 <div class="createArticleButton"></div>
             </section>
         </article>
-        <dialog class ="events__newEventForm"></dialog></dialog>
+        <dialog class ="events__newEventForm"></dialog>
     </article>
 
 

--- a/src/index.html
+++ b/src/index.html
@@ -40,6 +40,7 @@
                 <section class="articles__container"></section>
                 <div class="createArticleButton"></div>
             </section>
+            <section class="friend__container"></section>
         </article>
         <dialog class ="events__newEventForm"></dialog>
     </article>

--- a/src/index.html
+++ b/src/index.html
@@ -17,6 +17,7 @@
         </article>
         <article class="dashboard">
             <!-- All your Nutshell are belong here -->
+            <section class="friend__container"></section>
         </article>
     </article>
 

--- a/src/index.html
+++ b/src/index.html
@@ -40,7 +40,7 @@
                 <section class="articles__container"></section>
                 <div class="createArticleButton"></div>
             </section>
-            <section class="friend__container"></section>
+            <section class="friends"></section>
         </article>
         <dialog class ="events__newEventForm"></dialog>
     </article>

--- a/src/scripts/Nutshell.js
+++ b/src/scripts/Nutshell.js
@@ -1,5 +1,9 @@
+import { friendList } from "./friends/friendList.js"
+
 export const Nutshell = () => {
     // Render all your UI components here
     console.log("Nutshell has been rendered!")
     console.log("Session storage user id: ", sessionStorage.getItem("activeUser") )
+
+    friendList()
 }

--- a/src/scripts/Nutshell.js
+++ b/src/scripts/Nutshell.js
@@ -21,13 +21,12 @@ export const Nutshell = () => {
         messageList()
     })
     
+    friendList();
 
     newTaskButton();
     taskDialog();
     taskList();
 
-
-  
     // Will rener the createNewEventButton and list of upcoming events on initial page load
     createNewEventButton();
     eventList();
@@ -35,7 +34,7 @@ export const Nutshell = () => {
     console.log("Nutshell has been rendered!")
     console.log("Session storage user id: ", sessionStorage.getItem("activeUser") )
 
-    friendList()
+    
 
 
 

--- a/src/scripts/friends/friendForm.js
+++ b/src/scripts/friends/friendForm.js
@@ -1,0 +1,5 @@
+/**
+ * Gregory
+ * 
+ * Haven't got around to using this one yet.
+ */

--- a/src/scripts/friends/friendHTMLRep.js
+++ b/src/scripts/friends/friendHTMLRep.js
@@ -1,5 +1,3 @@
 export const friendHTMLRep = (friendObj) => {
-    return `
-        <div class="friend__display>${friendObj.friendId}</div>
-    `
+    return `<div class="friend__display">${friendObj.friendId}</div>`
 }

--- a/src/scripts/friends/friendHTMLRep.js
+++ b/src/scripts/friends/friendHTMLRep.js
@@ -1,3 +1,11 @@
+/**
+ * Gregory
+ * 
+ * This module takes a user object as an argument, wraps the username of said user
+ * in HTML, and returns the resulting string to the module that called the 
+ * friendHTMLRep function.
+ * 
+ */
 export const friendHTMLRep = (friendObj) => {
     return `
     <div class="friend__display">${friendObj.username}</div>

--- a/src/scripts/friends/friendHTMLRep.js
+++ b/src/scripts/friends/friendHTMLRep.js
@@ -1,5 +1,5 @@
 export const friendHTMLRep = (friendObj) => {
     return `
-    <div class="friend__display">${friendObj.friendId}</div>
+    <div class="friend__display">${friendObj.username}</div>
     `
 }

--- a/src/scripts/friends/friendHTMLRep.js
+++ b/src/scripts/friends/friendHTMLRep.js
@@ -1,0 +1,5 @@
+export const friendHTMLRep = (friendObj) => {
+    return `
+        <div class="friend__display>${friendObj.friendId}</div>
+    `
+}

--- a/src/scripts/friends/friendHTMLRep.js
+++ b/src/scripts/friends/friendHTMLRep.js
@@ -1,7 +1,10 @@
 /**
  * Gregory
  * 
- * This module takes a user object as an argument, wraps the username of said user
+ * This module returns HTML representing the Friends component to the DOM when
+ * friendContainerHTML is called.
+ * 
+ * The friendHTMLRep function takes a user object as an argument, wraps the username of said user
  * in HTML, and returns the resulting string to the module that called the 
  * friendHTMLRep function.
  * 
@@ -9,5 +12,16 @@
 export const friendHTMLRep = (friendObj) => {
     return `
     <div class="friend__display">${friendObj.username}</div>
+    `
+}
+
+export const friendContainerHTML = () => {
+    return `
+    <div class="friends__header">
+        <h3>Friends</h3>
+    </div>
+    <div class="friends__container"></div>
+    <button class="friends__add--button">Add Friends</button>
+    <dialog class="friends__form"></dialog>
     `
 }

--- a/src/scripts/friends/friendHTMLRep.js
+++ b/src/scripts/friends/friendHTMLRep.js
@@ -1,3 +1,5 @@
 export const friendHTMLRep = (friendObj) => {
-    return `<div class="friend__display">${friendObj.friendId}</div>`
+    return `
+    <div class="friend__display">${friendObj.friendId}</div>
+    `
 }

--- a/src/scripts/friends/friendList.js
+++ b/src/scripts/friends/friendList.js
@@ -1,7 +1,7 @@
 /**
  * Gregory 
  * 
- * This module pulls the currentUser:friend relationships from friendProvider.js, then
+ * This module pulls the currentUser-friend relationships from friendProvider.js, then
  * pulls all the users from userProvider.js. 
  * 
  * The module then finds all user objects that are friends of the current User and stores
@@ -26,18 +26,16 @@ export const friendList = () => {
     getFriends() 
         .then(() => {
             userFriends = useFriends() // an array of objects
-            //renderFriends(userFriends)
         })
     
     getUsers()
         .then(() => {
-            let allUsers = useUsers()
-            console.log("all users: ", allUsers)
-            const friendsOfUser = allUsers.filter(user => {
-                for (const friend of userFriends) {
-                    if (user.id === friend.friendId) {
-                        return user
-                    }
+            let allUsers = useUsers() // grab all user objects in the database
+            const friendsOfUser = allUsers.filter(user => { // Compare the id of each user in allUsers
+                for (const friend of userFriends) {         // to the friendId of each relationship in 
+                    if (user.id === friend.friendId) {      // userFriends. If there is a user whose ID
+                        return user                         // is found in userFriends, add that user object to
+                    }                                       // friendsOfUser
                 }
             })
 
@@ -47,12 +45,9 @@ export const friendList = () => {
 }
 
 const renderFriends = (friends) => {
-    const friendHTML = friends.map((friendObj) => {
-        return friendHTMLRep(friendObj)
-    }).join("")
-
-    console.log("Friend HTML: ", friendHTML)
-
+    const friendHTML = friends.map((friendObj) => { // Wrap each friend's username in HTML and join it
+        return friendHTMLRep(friendObj)             // to the friendHTML variable, which is then added 
+    }).join("")                                     // added to the DOM.
     contentTarget.innerHTML = friendHTML
 
     

--- a/src/scripts/friends/friendList.js
+++ b/src/scripts/friends/friendList.js
@@ -1,0 +1,31 @@
+import { getFriends, useFriends } from "./friendProvider.js"
+import { friendHTMLRep } from "./friendHTMLRep.js"
+
+
+export const friendList = () => {
+    const eventHub = document.querySelector(".container")
+    const contentTarget = document.querySelector(".friend__container")
+    const currentUserId = parseInt(sessionStorage.getItem("activeUser")) 
+    // The userId was stored when the user logged in. All Nutshell components will use this value.
+
+    const userFriends = []
+    // Here, we pull the user-friend relationships from the DB
+    // Only friend relationships that have the currentUserId as the userId will be pulled
+    getFriends() 
+        .then(() => {
+            userFriends = useFriends()
+            renderFriends(userFriends)
+        })
+
+}
+
+const renderFriends = (friends) => {
+    // const friendHTML = friends.map((friendObj) => {
+    //     return friendHTMLRep(friendObj)
+    // }).join("")
+
+    // contentTarget.innerHTML += friendHTML
+
+    console.log("Friend Objects for the current user: ", userFriends)
+}
+

--- a/src/scripts/friends/friendList.js
+++ b/src/scripts/friends/friendList.js
@@ -1,5 +1,17 @@
+/**
+ * Gregory 
+ * 
+ * This module pulls the currentUser:friend relationships from friendProvider.js, then
+ * pulls all the users from userProvider.js. 
+ * 
+ * The module then finds all user objects that are friends of the current User and stores
+ * them in the friendsOfUser variable and renders The usernames of said friends to the DOM.
+ * 
+ */
+
 import { getFriends, useFriends } from "./friendProvider.js"
 import { friendHTMLRep } from "./friendHTMLRep.js"
+import { getUsers, useUsers } from "../users/userProvider.js"
 
 const eventHub = document.querySelector(".container")
 const contentTarget = document.querySelector(".friend__container")
@@ -13,8 +25,23 @@ export const friendList = () => {
     // Only friend relationships that have the currentUserId as the userId will be pulled
     getFriends() 
         .then(() => {
-            userFriends = useFriends()
-            renderFriends(userFriends)
+            userFriends = useFriends() // an array of objects
+            //renderFriends(userFriends)
+        })
+    
+    getUsers()
+        .then(() => {
+            let allUsers = useUsers()
+            console.log("all users: ", allUsers)
+            const friendsOfUser = allUsers.filter(user => {
+                for (const friend of userFriends) {
+                    if (user.id === friend.friendId) {
+                        return user
+                    }
+                }
+            })
+
+            renderFriends(friendsOfUser)
         })
 
 }

--- a/src/scripts/friends/friendList.js
+++ b/src/scripts/friends/friendList.js
@@ -1,14 +1,14 @@
 import { getFriends, useFriends } from "./friendProvider.js"
 import { friendHTMLRep } from "./friendHTMLRep.js"
 
+const eventHub = document.querySelector(".container")
+const contentTarget = document.querySelector(".friend__container")
+const currentUserId = parseInt(sessionStorage.getItem("activeUser")) 
 
 export const friendList = () => {
-    const eventHub = document.querySelector(".container")
-    const contentTarget = document.querySelector(".friend__container")
-    const currentUserId = parseInt(sessionStorage.getItem("activeUser")) 
     // The userId was stored when the user logged in. All Nutshell components will use this value.
 
-    const userFriends = []
+    let userFriends = []
     // Here, we pull the user-friend relationships from the DB
     // Only friend relationships that have the currentUserId as the userId will be pulled
     getFriends() 
@@ -20,12 +20,14 @@ export const friendList = () => {
 }
 
 const renderFriends = (friends) => {
-    // const friendHTML = friends.map((friendObj) => {
-    //     return friendHTMLRep(friendObj)
-    // }).join("")
+    const friendHTML = friends.map((friendObj) => {
+        return friendHTMLRep(friendObj)
+    }).join("")
 
-    // contentTarget.innerHTML += friendHTML
+    console.log("Friend HTML: ", friendHTML)
 
-    console.log("Friend Objects for the current user: ", userFriends)
+    contentTarget.innerHTML = friendHTML
+
+    
 }
 

--- a/src/scripts/friends/friendList.js
+++ b/src/scripts/friends/friendList.js
@@ -25,13 +25,11 @@ export const friendList = () => {
     let userFriends = []
     // Here, we pull the user-friend relationships from the DB
     // Only friend relationships that have the currentUserId as the userId will be pulled
-    getFriends() 
-        .then(() => {
-            userFriends = useFriends() // an array of objects
-        })
     
     getUsers()
+        .then(getFriends)
         .then(() => {
+            userFriends = useFriends()
             let allUsers = useUsers() // grab all user objects in the database
             const friendsOfUser = allUsers.filter(user => { // Compare the id of each user in allUsers
                 for (const friend of userFriends) {         // to the friendId of each relationship in 

--- a/src/scripts/friends/friendList.js
+++ b/src/scripts/friends/friendList.js
@@ -10,15 +10,17 @@
  */
 
 import { getFriends, useFriends } from "./friendProvider.js"
-import { friendHTMLRep } from "./friendHTMLRep.js"
+import { friendHTMLRep, friendContainerHTML } from "./friendHTMLRep.js"
 import { getUsers, useUsers } from "../users/userProvider.js"
 
 const eventHub = document.querySelector(".container")
-const contentTarget = document.querySelector(".friend__container")
+const contentTarget = document.querySelector(".friends")
 const currentUserId = parseInt(sessionStorage.getItem("activeUser")) 
 
 export const friendList = () => {
-    // The userId was stored when the user logged in. All Nutshell components will use this value.
+    const friendHTMLContainer = friendContainerHTML()
+    contentTarget.innerHTML = friendHTMLContainer
+    const contentElement = document.querySelector(".friends__container")
 
     let userFriends = []
     // Here, we pull the user-friend relationships from the DB
@@ -39,16 +41,16 @@ export const friendList = () => {
                 }
             })
 
-            renderFriends(friendsOfUser)
+            renderFriends(friendsOfUser, contentElement)
         })
 
 }
 
-const renderFriends = (friends) => {
+const renderFriends = (friends, contentElement) => {
     const friendHTML = friends.map((friendObj) => { // Wrap each friend's username in HTML and join it
         return friendHTMLRep(friendObj)             // to the friendHTML variable, which is then added 
     }).join("")                                     // added to the DOM.
-    contentTarget.innerHTML = friendHTML
+    contentElement.innerHTML = friendHTML
 
     
 }

--- a/src/scripts/friends/friendProvider.js
+++ b/src/scripts/friends/friendProvider.js
@@ -17,7 +17,6 @@ export const getFriends = () => {
         .then(response => response.json())
         .then(parsedFriends => {
             friends = parsedFriends
-            console.log("friends array: ", friends)
         })
         .then(() => { 
             // Make sure that only the current user's friends are returned
@@ -30,6 +29,5 @@ export const getFriends = () => {
 }
 
 export const useFriends = () => {
-    console.log(userFriends)
     return userFriends.slice()
 }

--- a/src/scripts/friends/friendProvider.js
+++ b/src/scripts/friends/friendProvider.js
@@ -10,7 +10,6 @@
 let friends = []
 let userFriends = []
 
-const currentUserId = parseInt(sessionStorage.getItem("activeUser"))
 
 export const getFriends = () => {
     return fetch("http://localhost:8088/friends")
@@ -19,6 +18,7 @@ export const getFriends = () => {
             friends = parsedFriends
         })
         .then(() => { 
+            const currentUserId = parseInt(sessionStorage.getItem("activeUser"))
             // Make sure that only the current user's friends are returned
             userFriends = friends.filter((friend) => {
                 if (friend.userId === currentUserId) {

--- a/src/scripts/friends/friendProvider.js
+++ b/src/scripts/friends/friendProvider.js
@@ -7,20 +7,21 @@
  * The users friends can then be retrieved for use by other modules using useFriends()
  * 
  */
+let friends = []
 let userFriends = []
 
 const currentUserId = parseInt(sessionStorage.getItem("activeUser"))
 
 export const getFriends = () => {
-    let friends = []
-    return fetch('http://localhost:8088/friends')
+    return fetch("http://localhost:8088/friends")
         .then(response => response.json())
         .then(parsedFriends => {
             friends = parsedFriends
+            console.log("friends array: ", friends)
         })
-        .then((friends) => { 
+        .then(() => { 
             // Make sure that only the current user's friends are returned
-            userFriends = friends.map((friend) => {
+            userFriends = friends.filter((friend) => {
                 if (friend.userId === currentUserId) {
                     return friend
                 } 
@@ -29,5 +30,6 @@ export const getFriends = () => {
 }
 
 export const useFriends = () => {
+    console.log(userFriends)
     return userFriends.slice()
 }

--- a/src/scripts/friends/friendProvider.js
+++ b/src/scripts/friends/friendProvider.js
@@ -1,0 +1,33 @@
+/**
+ * Gregory Thompson
+ * 
+ * This module fetches the friend relationships from the database using getFriends(), then filters
+ *  and stores all the friend objects that have the currentUserId listed as the userId.
+ * 
+ * The users friends can then be retrieved for use by other modules using useFriends()
+ * 
+ */
+let userFriends = []
+
+const currentUserId = parseInt(sessionStorage.getItem("activeUser"))
+
+export const getFriends = () => {
+    let friends = []
+    return fetch('http://localhost:8088/friends')
+        .then(response => response.json())
+        .then(parsedFriends => {
+            friends = parsedFriends
+        })
+        .then((friends) => { 
+            // Make sure that only the current user's friends are returned
+            userFriends = friends.map((friend) => {
+                if (friend.userId === currentUserId) {
+                    return friend
+                } 
+            })
+        })
+}
+
+export const useFriends = () => {
+    return userFriends.slice()
+}

--- a/src/styles/friends.css
+++ b/src/styles/friends.css
@@ -1,0 +1,17 @@
+.friends {
+    border: 1px solid black;
+}
+
+.friends__header {
+    line-height: 0;
+}
+
+.friends__container {
+    overflow: auto;
+    /* adds a scrollbar when the list of friends
+    becomes too big for the container */
+}
+
+.friends__add--button {
+    margin: 5px;
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,5 +1,5 @@
 @import "homepage.css";
-
+@import "friends.css";
 @import "messages.css";
 @import "tasks.css";
 


### PR DESCRIPTION
# Description
New code in the friends component now renders the usernames of all friends of the current user to the DOM
Fixes # (15)
## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)
# Testing Instructions
1. In order for friends to function properly for all users, there needs to be 2 friend objects in the database for each friend relationship. For example, if a user with an ID of 1 is friends with a user with an ID of 2, you will need the following friend objects:

          {
          "id":1,
          "userId": 1,
          "friendId": 2
          },
          {
          "id":2,
          "userId": 2,
          "friendId":1
          }
 
     That way, the code knows that user 1 has user 2 as a friend, and that user 2 has 
     user 1 as a friend as well.

2. Once you have sufficient friend objects in the database, load the page and log in. You should see the usernames of all friends at the bottom of the page under the 'Friends' header, followed by a currently useless 'Add Friends' button.

# Checklist:
- [✅] My code follows the style guidelines of this project
- [✅] I have performed a self-review of my own code
- [✅] I have commented my code, particularly in hard-to-understand areas
- [✅] My changes generate no new warnings or errors
- [✅] I have added test instructions that prove my fix is effective or that my feature works
